### PR TITLE
feat(cli): add shell completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +581,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "dirs",
  "env_logger",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5.1", features = ["derive"] }
+clap_complete = "4.5.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ This system ensures that rule IDs remain stable across import, export, and sync 
 - `rulesify import --tool <tool> <file>` - Import existing rule from AI tool format to URF
 - `rulesify import --tool <tool> <file> --rule-id <custom-id>` - Import with custom rule ID
 
+### Shell Completion
+- `rulesify completion <shell>` - Generate shell completion script (bash, zsh, fish, etc.)
+
 **Global Options (available on all commands):**
 - `--config <path>` - Use custom configuration file
 - `--verbose` - Enable detailed output for debugging

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use clap::{Command, CommandFactory};
+use clap_complete::{generate, Generator, Shell};
+use std::io;
+use std::path::PathBuf;
+use crate::cli::Cli;
+
+pub fn run(shell: Shell, _config_path: Option<PathBuf>) -> Result<()> {
+    let mut cmd = Cli::command();
+    print_completions(shell, &mut cmd);
+    Ok(())
+}
+
+fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod import;
 pub mod rule;
 pub mod sync;
 pub mod validate;
+pub mod completion;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 use log::{debug, error};
 use std::path::PathBuf;
 
@@ -22,7 +23,8 @@ EXAMPLES:
     rulesify deploy --all                 # Deploy all rules to all tools
     rulesify deploy --tool cursor --all   # Deploy to Cursor only
     rulesify config show                  # Show current configuration
-    rulesify sync --dry-run               # Preview sync changes"#
+    rulesify sync --dry-run               # Preview sync changes
+    rulesify completion shell             # Generate shell completion script"#
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -84,6 +86,11 @@ pub enum Commands {
         #[command(subcommand)]
         action: commands::config::ConfigAction,
     },
+    /// Generate shell completion scripts
+    Completion {
+        #[arg(help = "Shell to generate completion for")]
+        shell: Shell,
+    },
 }
 
 impl Cli {
@@ -131,6 +138,10 @@ impl Cli {
             Commands::Config { action } => {
                 debug!("Executing config command: {:?}", action);
                 commands::config::run(action, self.config)
+            }
+            Commands::Completion { shell } => {
+                debug!("Generating completion script for shell: {:?}", shell);
+                commands::completion::run(shell, self.config)
             }
         };
 

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -646,3 +646,109 @@ fn test_cli_verbose_output() {
     assert_eq!(exit_code, 0);
     assert!(stdout.contains("Rulesify manages Universal Rule Files"));
 }
+
+#[test]
+fn test_cli_completion_command_bash() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+    // Test bash completion generation
+    let (stdout, stderr, exit_code) = run_rulesify_command(
+        &["completion", "bash"],
+        temp_dir.path(),
+    )
+    .expect("Failed to run rulesify completion bash");
+
+    assert_eq!(exit_code, 0, "Command failed with stderr: {}", stderr);
+    assert!(stdout.contains("_rulesify"), "Bash completion should contain function name");
+    assert!(stdout.contains("complete"), "Bash completion should contain complete command");
+    assert!(stdout.len() > 100, "Bash completion should be substantial");
+}
+
+#[test]
+fn test_cli_completion_command_zsh() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+    // Test zsh completion generation
+    let (stdout, stderr, exit_code) = run_rulesify_command(
+        &["completion", "zsh"],
+        temp_dir.path(),
+    )
+    .expect("Failed to run rulesify completion zsh");
+
+    assert_eq!(exit_code, 0, "Command failed with stderr: {}", stderr);
+    assert!(stdout.contains("_rulesify"), "Zsh completion should contain function name");
+    assert!(stdout.contains("compdef"), "Zsh completion should contain compdef");
+    assert!(stdout.len() > 100, "Zsh completion should be substantial");
+}
+
+#[test]
+fn test_cli_completion_command_fish() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+    // Test fish completion generation
+    let (stdout, stderr, exit_code) = run_rulesify_command(
+        &["completion", "fish"],
+        temp_dir.path(),
+    )
+    .expect("Failed to run rulesify completion fish");
+
+    assert_eq!(exit_code, 0, "Command failed with stderr: {}", stderr);
+    assert!(stdout.contains("complete"), "Fish completion should contain complete command");
+    assert!(stdout.contains("rulesify"), "Fish completion should reference rulesify");
+    assert!(stdout.len() > 100, "Fish completion should be substantial");
+}
+
+#[test]
+fn test_cli_completion_command_powershell() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+    // Test PowerShell completion generation
+    let (stdout, stderr, exit_code) = run_rulesify_command(
+        &["completion", "powershell"],
+        temp_dir.path(),
+    )
+    .expect("Failed to run rulesify completion powershell");
+
+    assert_eq!(exit_code, 0, "Command failed with stderr: {}", stderr);
+    assert!(stdout.contains("Register-ArgumentCompleter"), "PowerShell completion should contain Register-ArgumentCompleter");
+    assert!(stdout.contains("rulesify"), "PowerShell completion should reference rulesify");
+    assert!(stdout.len() > 100, "PowerShell completion should be substantial");
+}
+
+#[test]
+fn test_cli_completion_command_invalid_shell() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+    // Test invalid shell
+    let (stdout, stderr, exit_code) = run_rulesify_command(
+        &["completion", "invalid-shell"],
+        temp_dir.path(),
+    )
+    .expect("Failed to run rulesify completion with invalid shell");
+
+    assert_ne!(exit_code, 0, "Command should fail with invalid shell");
+    assert!(
+        stdout.contains("invalid value") || stderr.contains("invalid value") ||
+        stdout.contains("possible values") || stderr.contains("possible values"),
+        "Should indicate invalid shell value"
+    );
+}
+
+#[test]
+fn test_cli_completion_command_help() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+    // Test completion help
+    let (stdout, stderr, exit_code) = run_rulesify_command(
+        &["completion", "--help"],
+        temp_dir.path(),
+    )
+    .expect("Failed to run rulesify completion --help");
+
+    assert_eq!(exit_code, 0, "Command failed with stderr: {}", stderr);
+    assert!(stdout.contains("Generate shell completion scripts"), "Help should describe completion functionality");
+    assert!(stdout.contains("bash"), "Help should mention bash");
+    assert!(stdout.contains("zsh"), "Help should mention zsh");
+    assert!(stdout.contains("fish"), "Help should mention fish");
+    assert!(stdout.contains("powershell"), "Help should mention powershell");
+}


### PR DESCRIPTION
Since I use rulesify often, I added shell completion to make typing and navigating commands easier. This is a small quality-of-life improvement that I believe will also benefit other frequent users. With tab-completion, you can explore available commands like help, completion, config, deploy, etc., simply by typing:
`rulesify <TAB>`
This feature is optional, but enhances usability for supported shells like `bash`, `zsh`, and `fish`.
Thanks for making this such a useful tool! 👍

## Summary
- Added `completion` subcommand to generate shell completion scripts
- Supports various shells via `rulesify completion <SHELL>`
- Updated `README.md` with usage instructions
- Modified `install.sh` to install Bash completion
- Updated CLI module structure to include completion command
- Added CLI integration test for completion command