### PR TITLE
fix: rename GITHUB_TOKEN to GH_TOKEN in GitHub Actions workflow

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -9,7 +9,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL }}
     

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,8 +204,8 @@ cargo watch -x check
 ### Registry Automation
 
 ```bash
-# Update registry from GitHub repos (requires GITHUB_TOKEN)
-GITHUB_TOKEN=your_token cargo run --bin update-registry
+# Update registry from GitHub repos (requires GH_TOKEN)
+GH_TOKEN=your_token cargo run --bin update-registry
 
 # Run with verbose logging
 RUST_LOG=debug cargo run --bin update-registry

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The registry updates weekly via GitHub Actions. To manually refresh:
 
 ```bash
 # Requires GitHub and OpenRouter tokens
-GITHUB_TOKEN=xxx OPENROUTER_API_KEY=xxx cargo run --bin update-registry
+GH_TOKEN=xxx OPENROUTER_API_KEY=xxx cargo run --bin update-registry
 
 # Force re-classification
 cargo run --bin update-registry -- --force

--- a/src/bin/update-registry.rs
+++ b/src/bin/update-registry.rs
@@ -172,12 +172,12 @@ async fn main() -> Result<()> {
     log::info!("Starting registry update");
     log::info!("Args: force={}, verbose={}", args.force, args.verbose);
 
-    let token = std::env::var("GITHUB_TOKEN").ok();
+    let token = std::env::var("GH_TOKEN").ok();
     let client = if let Some(t) = token {
         log::info!("Using authenticated GitHub API");
         GitHubClient::with_token(Some(t))
     } else {
-        log::warn!("No GITHUB_TOKEN set - using unauthenticated API (60 requests/hr rate limit)");
+        log::warn!("No GH_TOKEN set - using unauthenticated API (60 requests/hr rate limit)");
         GitHubClient::new()
     };
     let scorer = Scorer::default();


### PR DESCRIPTION
## Summary
- Renamed environment variable from `GITHUB_TOKEN` to `GH_TOKEN` in the update-registry workflow
- Updated `update-registry.rs` binary to read `GH_TOKEN` instead of `GITHUB_TOKEN`
- Updated documentation in README.md and AGENTS.md

GitHub Actions reserves the `GITHUB_` prefix for environment variables, so custom env vars cannot use this prefix. This fix ensures the workflow can properly authenticate with the GitHub API.