### PR TITLE
fix: remove workflow_dispatch from release-build and install.sh uploads

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -85,9 +85,7 @@ jobs:
               --prerelease
           fi
 
-          # Keep install.sh available on edge tags too
-          gh release upload "$EDGE_TAG" install.sh --clobber
-          gh release upload "$EDGE_SHA_TAG" install.sh --clobber
+          
 
   build-edge-assets:
     name: Build Edge Assets

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -3,17 +3,10 @@ name: Production Release
 on:
   push:
     tags:
-      - 'v*' # Trigger on version tags
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to build/release (e.g., v0.3.0)'
-        required: true
-        type: string
+      - 'v*'
 
 env:
   CARGO_TERM_COLOR: always
-  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
 
 # Add permissions block at workflow level
 permissions:
@@ -25,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -33,8 +26,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git rev-parse "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1 || {
-            echo "Tag ${RELEASE_TAG} not found. Create it first (e.g. via Releases workflow)."
+          git rev-parse "refs/tags/${{ github.ref_name }}" >/dev/null 2>&1 || {
+            echo "Tag ${{ github.ref_name }} not found. Create it first (e.g. via Releases workflow)."
             exit 1
           }
 
@@ -56,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -65,17 +58,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+          TAG="${{ github.ref_name }}"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Generate Release Notes
         id: release_notes
         run: |
           echo "## Rulesify CLI v${{ steps.get_version.outputs.version }}" > RELEASE_NOTES.md
-          echo "" >> RELEASE_NOTES.md
-          echo "### Installation" >> RELEASE_NOTES.md
-          echo '```bash' >> RELEASE_NOTES.md
-          echo "curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh | sh" >> RELEASE_NOTES.md
-          echo '```' >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
           echo "### Changelog" >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
@@ -105,19 +94,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Check if release already exists (created by releases workflow)
-          if gh release view "${RELEASE_TAG}" &>/dev/null; then
+          if gh release view "${{ github.ref_name }}" &>/dev/null; then
             echo "Release already exists, updating notes..."
-            gh release edit "${RELEASE_TAG}" --notes-file RELEASE_NOTES.md
-            UPLOAD_URL=$(gh api repos/${{ github.repository }}/releases/tags/"${RELEASE_TAG}" | jq -r .upload_url)
+            gh release edit "${{ github.ref_name }}" --notes-file RELEASE_NOTES.md
+            UPLOAD_URL=$(gh api repos/${{ github.repository }}/releases/tags/"${{ github.ref_name }}" | jq -r .upload_url)
           else
             # Create the release using gh cli
-            gh release create "${RELEASE_TAG}" \
+            gh release create "${{ github.ref_name }}" \
               --title "Rulesify CLI ${{ steps.get_version.outputs.version }}" \
               --notes-file RELEASE_NOTES.md \
               --draft=false \
               --prerelease=false
             # Get the release upload URL and set it as output
-            UPLOAD_URL=$(gh api repos/${{ github.repository }}/releases/tags/"${RELEASE_TAG}" | jq -r .upload_url)
+            UPLOAD_URL=$(gh api repos/${{ github.repository }}/releases/tags/"${{ github.ref_name }}" | jq -r .upload_url)
           fi
           echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
 
@@ -147,7 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -178,9 +167,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            gh release upload "${RELEASE_TAG}" ${{ matrix.asset_name }}.zip --clobber
+            gh release upload "${{ github.ref_name }}" ${{ matrix.asset_name }}.zip --clobber
           else
-            gh release upload "${RELEASE_TAG}" ${{ matrix.asset_name }}.tar.gz --clobber
+            gh release upload "${{ github.ref_name }}" ${{ matrix.asset_name }}.tar.gz --clobber
           fi
 
       - name: Upload Checksum
@@ -189,30 +178,10 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            gh release upload "${RELEASE_TAG}" ${{ matrix.asset_name }}.zip.sha256 --clobber
+            gh release upload "${{ github.ref_name }}" ${{ matrix.asset_name }}.zip.sha256 --clobber
           else
-            gh release upload "${RELEASE_TAG}" ${{ matrix.asset_name }}.tar.gz.sha256 --clobber
+            gh release upload "${{ github.ref_name }}" ${{ matrix.asset_name }}.tar.gz.sha256 --clobber
           fi
-
-  upload-install-script:
-    needs: create-release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Upload Install Script
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${RELEASE_TAG}" install.sh --clobber
-
-      - name: Upload CHANGELOG
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${RELEASE_TAG}" CHANGELOG.md --clobber
 
   update-homebrew:
     needs: build-and-release
@@ -221,14 +190,15 @@ jobs:
       - name: Get version
         id: version
         run: |
-          VERSION="${RELEASE_TAG#v}"
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Fetch checksums from release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download "${RELEASE_TAG}" \
+          gh release download "${{ github.ref_name }}" \
             --pattern "rulesify-darwin-amd64.tar.gz.sha256" \
             --pattern "rulesify-darwin-arm64.tar.gz.sha256" \
             --dir checksums


### PR DESCRIPTION
## Summary
- Remove `workflow_dispatch` trigger from `release-build.yml` to prevent manual runs with non-existent tags
- Remove install.sh uploads from both production and edge releases
- Replace `RELEASE_TAG` env variable with `github.ref_name` throughout

## Motivation
The manual trigger caused confusion when users tried to run "Production Release" with a tag that doesn't exist. The correct flow is:
1. Run `release-automation.yml` → `production-tag` action → creates tag
2. Tag push automatically triggers `release-build.yml`

Install script is no longer needed as users install via Homebrew or direct binary downloads.

## Test Plan
1. Merge this PR
2. Run `release-automation.yml` with `action: production-tag` and `release_version: 0.5.0`
3. Verify tag is created and `release-build.yml` is triggered automatically